### PR TITLE
fix: hover state of reload button

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   # Trigger the workflow every time you push to the `main` branch
   # Using a different branch name? Replace `main` with your branch’s name
   push:
-    branches: [main]
+    branches: [main, fix/reload-button]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   # Trigger the workflow every time you push to the `main` branch
   # Using a different branch name? Replace `main` with your branch’s name
   push:
-    branches: [main, fix/reload-button]
+    branches: [main]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Inspired by [@0xb10c](https://github.com/0xb10c)'s list of [Public Bitcoin Feera
 
 Following APIs can't be supported due missing data:
 
-- [Bitcoiner.live](https://bitcoiner.live/api/fees/estimates/latest) it starts calculation of estimated fees for next 30min, but not before. That's 'fast' fees for next block are missing.
+- [Bitcoiner.live](https://bitcoiner.live/api/fees/estimates/latest) starts calculation of estimated fees for next 30min, but not before. That's 'fast' fees for next block are missing.
 - [Blockchair](https://api.blockchair.com/bitcoin/stats) supports a single `suggested_transaction_fee_per_byte_sat` only, but no relationship to next blocks.
 - [BTC.com](https://btc.com/service/fees/distribution) supports a `one_block_fee` only, but no relationship to next blocks.
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Inspired by [@0xb10c](https://github.com/0xb10c)'s list of [Public Bitcoin Feera
 - [Esplora](https://github.com/Blockstream/esplora/)
 - [Bitgo](https://developers.bitgo.com/explorer)
 - [Blockcypher](https://www.blockcypher.com/dev/bitcoin/)
-- [Blockchain.info](https://www.blockchain.com/explorer/api):
+- [Blockchain.info](https://www.blockchain.com/explorer/api)
 
 Following APIs can't be supported due missing data:
 
-- [Bitcoiner.live](https://bitcoiner.live/api/fees/estimates/latest): It starts calculation of estimated fees for next 30min, but not before. That's 'fast' fees for next block are missing.
-- [Blockchair](https://api.blockchair.com/bitcoin/stats) Supports a single `suggested_transaction_fee_per_byte_sat` only, but no relationship to next blocks.
-- [BTC.com](https://btc.com/service/fees/distribution) Supports a `one_block_fee` only, but no relationship to next blocks.
+- [Bitcoiner.live](https://bitcoiner.live/api/fees/estimates/latest) it starts calculation of estimated fees for next 30min, but not before. That's 'fast' fees for next block are missing.
+- [Blockchair](https://api.blockchair.com/bitcoin/stats) supports a single `suggested_transaction_fee_per_byte_sat` only, but no relationship to next blocks.
+- [BTC.com](https://btc.com/service/fees/distribution) supports a `one_block_fee` only, but no relationship to next blocks.
 
 ## Build
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -172,6 +172,7 @@
       class="group relative h-12 w-12 md:h-14 md:w-14"
       title="Refresh fees"
       on:click={() => send({ type: 'fees.load' })}
+      disabled={AD.isLoading($fees)}
     >
       <div
         class="h-full w-full rounded-full border-[2px] border-gray-200 dark:border-gray-600"
@@ -191,7 +192,7 @@
         {/if}
       </div>
       <div
-        class="absolute inset-x-[4px] inset-y-[4px] flex items-center justify-center rounded-full border-2 border-transparent bg-orange-400 opacity-0 group-hover:opacity-100"
+        class="ease absolute inset-x-[4px] inset-y-[4px] flex items-center justify-center rounded-full border-2 border-transparent bg-gray-300 dark:bg-gray-700 [@media(any-hover:hover)]:opacity-0 [@media(any-hover:hover)]:group-hover:bg-orange-400 [@media(hover:hover)]:group-hover:opacity-100"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -195,9 +195,9 @@
         class={twMerge(
           'absolute inset-x-[4px] inset-y-[4px]',
           'flex items-center justify-center',
-          'rounded-full border-2 border-transparent bg-gray-300 group-hover:bg-orange-400 group-hover:opacity-100 dark:bg-gray-700',
+          'rounded-full border-2 border-transparent bg-gray-300 hover:bg-green-400 hover:opacity-100 dark:bg-gray-700',
           'ease',
-          percent > 0 ? 'opacity-0' : ''
+          percent > 0 && 'opacity-0'
         )}
       >
         <svg

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -173,7 +173,6 @@
       class="group relative h-12 w-12 md:h-14 md:w-14"
       title="Refresh fees"
       on:click={() => send({ type: 'fees.load' })}
-      disabled={AD.isLoading($fees)}
     >
       <div
         class="h-full w-full rounded-full border-[2px] border-gray-200 dark:border-gray-600"
@@ -196,7 +195,7 @@
         class={twMerge(
           'absolute inset-x-[4px] inset-y-[4px]',
           'flex items-center justify-center',
-          'hover:bg-orange rounded-full border-2 border-transparent bg-gray-300 group-hover:opacity-100 group-active:bg-orange-400 group-active:opacity-100 dark:bg-gray-700',
+          'rounded-full border-2 border-transparent bg-gray-300 group-hover:bg-orange-400 group-hover:opacity-100 dark:bg-gray-700',
           'ease',
           percent > 0 && 'opacity-0'
         )}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -69,7 +69,7 @@
   })
 
   const feesStatus = tv({
-    base: 'rounded-full w-2 h-2 ease mt-1',
+    base: 'rounded-full w-2 h-2 ease',
     variants: {
       status: {
         initial: 'bg-gray-300',
@@ -195,9 +195,8 @@
         class={twMerge(
           'absolute inset-x-[4px] inset-y-[4px]',
           'flex items-center justify-center',
-          'rounded-full border-2 border-transparent bg-gray-300 hover:bg-green-400 hover:opacity-100 dark:bg-gray-700',
-          'ease',
-          percent > 0 && 'opacity-0'
+          'rounded-full border-2 border-transparent bg-blue-400 opacity-0  group-hover:opacity-100 dark:bg-gray-700',
+          'ease'
         )}
       >
         <svg

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -197,7 +197,7 @@
           'flex items-center justify-center',
           'rounded-full border-2 border-transparent bg-gray-300 group-hover:bg-orange-400 group-hover:opacity-100 dark:bg-gray-700',
           'ease',
-          percent > 0 && 'opacity-0'
+          percent > 0 ? 'opacity-0' : ''
         )}
       >
         <svg

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,7 +13,6 @@
   import { useSelector } from '@xstate/svelte'
   import { Fees, entries, isEndpoint, type Theme } from './types'
   import Fee from './component/Fee.svelte'
-  import { twMerge } from 'tailwind-merge'
   import { onMount } from 'svelte'
   import Settings from './component/Settings.svelte'
   import { fade } from 'svelte/transition'
@@ -192,12 +191,7 @@
         {/if}
       </div>
       <div
-        class={twMerge(
-          'absolute inset-x-[4px] inset-y-[4px]',
-          'flex items-center justify-center',
-          'rounded-full border-2 border-transparent bg-blue-400 opacity-0  group-hover:opacity-100 dark:bg-gray-700',
-          'ease'
-        )}
+        class="absolute inset-x-[4px] inset-y-[4px] flex items-center justify-center rounded-full border-2 border-transparent bg-orange-400 opacity-0 group-hover:opacity-100"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
it does not disappear (mobile only).

To fix that. use `media` queries to avoid hover state on mobile.

- CSS `@media (any-hover: hover)` https://developer.mozilla.org/en-US/docs/Web/CSS/@media/any-hover
- Tailwind `[@media(any-hover:hover){&:hover}]:opacity-100` https://tailwindcss.com/docs/hover-focus-and-other-states#using-arbitrary-variants