### PR TITLE
better schemes to handle data of localstorage

### DIFF
--- a/src/component/EditableUrlInput.svelte
+++ b/src/component/EditableUrlInput.svelte
@@ -174,7 +174,3 @@
     </div>
   {/if}
 </div>
-<div class="flex flex-col">
-  <!-- <p>value {JSON.stringify($snapshot.value)}</p> -->
-  <!-- <p>entered {$snapshot.context.enteredValue}!</p> -->
-</div>

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -1,5 +1,4 @@
-import { EndpointSchema, type EndpointMap } from '../types'
-import * as S from '@effect/schema/Schema'
+import { type EndpointMap } from '../types'
 import * as Mempool from '../api/mempool'
 import * as Esplora from '../api/esplora'
 import * as Bitgo from '../api/bitgo'
@@ -20,24 +19,5 @@ export const mockEndpointMap = (
   custom?: Partial<EndpointMap>
 ): EndpointMap => ({
   ...defaultEndpointMap(),
-  ...custom,
-})
-
-const EndpointMapJSONSchema = S.record(EndpointSchema, S.string)
-type EndpointMapJSON = S.Schema.To<typeof EndpointMapJSONSchema>
-
-const defaultEndpointMapJSON = (): EndpointMapJSON => ({
-  mempool: Mempool.DEFAULT_ENDPOINT_URL,
-  esplora: Esplora.DEFAULT_ENDPOINT_URL,
-  'rpc-explorer': Rpc.DEFAULT_ENDPOINT_URL,
-  bitgo: Bitgo.DEFAULT_ENDPOINT_URL,
-  blockcypher: Blockcypher.DEFAULT_ENDPOINT_URL,
-  blockchain: Blockchain.DEFAULT_ENDPOINT_URL,
-})
-
-export const mockEndpointMapJSON = (
-  custom?: Partial<EndpointMapJSON>
-): EndpointMapJSON => ({
-  ...defaultEndpointMapJSON(),
   ...custom,
 })

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -7,7 +7,7 @@ import {
 } from './types'
 import * as S from '@effect/schema/Schema'
 import { pipe, Effect } from 'effect'
-import { mockEndpointMap, mockEndpointMapJSON } from './test/mocks'
+import { mockEndpointMap } from './test/mocks'
 
 describe('Endpoint', () => {
   test('isEndpoint', () => {
@@ -63,27 +63,10 @@ describe('EndpointMapSchema', () => {
     blockchain: new URL(url6),
   })
 
-  const endpointMapJSON = mockEndpointMapJSON({
-    mempool: url1,
-    esplora: url2,
-    'rpc-explorer': url3,
-    bitgo: url4,
-    blockcypher: url5,
-    blockchain: url6,
-  })
-
-  const endpointMapString = JSON.stringify(endpointMapJSON)
+  const endpointMapString = pipe(endpointMap, S.encodeSync(EndpointMapSchema))
 
   test('decode string -> valid', () => {
-    const result = pipe(
-      endpointMapString,
-      S.decodeSync(S.parseJson(EndpointMapSchema))
-    )
-    expect(result).toEqual(endpointMap)
-  })
-
-  test('decode json -> valid', () => {
-    const result = pipe(endpointMapJSON, S.decodeSync(EndpointMapSchema))
+    const result = pipe(endpointMapString, S.decodeSync(EndpointMapSchema))
     expect(result).toEqual(endpointMap)
   })
 
@@ -97,17 +80,8 @@ describe('EndpointMapSchema', () => {
     ).rejects.toThrow()
   })
 
-  test('encode -> JSON', () => {
-    const result = pipe(endpointMap, S.encodeSync(EndpointMapSchema))
-    expect(result).toEqual(endpointMapJSON)
-  })
-
   test('encode -> string', () => {
-    const result = pipe(
-      endpointMap,
-      S.encodeSync(EndpointMapSchema),
-      JSON.stringify
-    )
+    const result = pipe(endpointMap, S.encodeSync(EndpointMapSchema))
     expect(result).toEqual(endpointMapString)
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import * as S from '@effect/schema/Schema'
 import type { AsyncData } from './util/async'
 import { UrlSchema } from './util/url'
 
-export const ThemeSchema = S.literal('dark', 'light')
+export const ThemeSchema = S.parseJson(S.literal('dark', 'light'))
 
 export type Theme = S.Schema.To<typeof ThemeSchema>
 
@@ -20,7 +20,9 @@ export const EndpointSchema = S.literal(...ENDPOINTS)
 
 export type Endpoint = S.Schema.To<typeof EndpointSchema>
 
-export const EndpointMapSchema = S.record(EndpointSchema, UrlSchema)
+export const EndpointMapSchema = S.parseJson(
+  S.record(EndpointSchema, UrlSchema)
+)
 
 export type EndpointMap = S.Schema.To<typeof EndpointMapSchema>
 

--- a/src/util/storage.ts
+++ b/src/util/storage.ts
@@ -14,13 +14,16 @@ import {
 const KEY_ENDPOITNS = 'endpoints'
 const KEY_THEME = 'theme'
 
-const getLocalStorage = <A, E, R>(key: string, schema: S.Schema<A, E, R>) => {
+const getLocalStorage = <A>(
+  key: string,
+  schema: S.Schema<A, string, never>
+) => {
   const effect = pipe(
     KeyValueStore.KeyValueStore,
     Effect.flatMap((kv) => kv.get(key)),
     // In case there is no value, set empty string to break decoding in next step
     Effect.map(O.getOrElse(() => '')),
-    Effect.flatMap(S.decodeUnknown(S.parseJson(schema)))
+    Effect.flatMap(S.decodeUnknown(schema))
   )
   return Effect.provide(effect, BrowserKeyValueStore.layerLocalStorage)
 }
@@ -30,18 +33,18 @@ export const getEndpoints = () =>
 
 export const getTheme = () => getLocalStorage(KEY_THEME, ThemeSchema)
 
-const setLocalStorage = <A, E, R>(
+const setLocalStorage = <A>(
   value: A,
   key: string,
-  schema: S.Schema<A, E, R>
+  schema: S.Schema<A, string, never>
 ) => {
   const effect = pipe(
     value,
     S.encode(schema),
-    Effect.flatMap((json) =>
+    Effect.flatMap((encoded) =>
       pipe(
         KeyValueStore.KeyValueStore,
-        Effect.flatMap((kv) => kv.set(key, JSON.stringify(json)))
+        Effect.flatMap((kv) => kv.set(key, encoded))
       )
     )
   )


### PR DESCRIPTION
[`parseJson`](https://effect-ts.github.io/effect/schema/Schema.ts.html#parsejson) combinator is used for encoding records into a string (instead into a object). Needed to serialize data before storing into `localstorage` (the only place where we do need this schema). In other case revert this PR or provide another schema without `parseJson`. 